### PR TITLE
pythonocc-core conda package support for all platforms

### DIFF
--- a/conda-pkg/pythonocc-core/bld.bat
+++ b/conda-pkg/pythonocc-core/bld.bat
@@ -1,0 +1,35 @@
+mkdir build
+cd build
+
+REM Remove dot from PY_VER for use in library name
+set MY_PY_VER=%PY_VER:.=%
+
+REM Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+ -DCMAKE_BUILD_TYPE=Release ^
+ -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DCMAKE_SYSTEM_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DPYTHON_EXECUTABLE:FILEPATH="%PYTHON%" ^
+ -DPYTHON_INCLUDE_DIR:PATH="%PREFIX%"/include ^
+ -DPYTHON_LIBRARY:FILEPATH="%PREFIX%"/libs/python%MY_PY_VER%.lib ^
+ -DPYTHONOCC_INSTALL_DIRECTORY=%SP_DIR%/OCC ^
+ -DPYTHONOCC_WRAP_DATAEXCHANGE=ON ^
+ -DPYTHONOCC_WRAP_OCAF=ON ^
+ -DPYTHONOCC_WRAP_VISU=ON ^
+ ..
+if errorlevel 1 exit 1
+ 
+REM Build step 
+ninja
+if errorlevel 1 exit 1
+
+REM Install step
+ninja install
+if errorlevel 1 exit 1
+
+REM copy the swig interface files. There are software projects
+REM that might require these files to build own modules on top
+REM of pythonocc-core
+cd ..
+xcopy src "%LIBRARY_PREFIX%\src\pythonocc-core\src" /s /e /i
+if errorlevel 1 exit 1

--- a/conda-pkg/pythonocc-core/build.sh
+++ b/conda-pkg/pythonocc-core/build.sh
@@ -1,51 +1,54 @@
 #!/bin/bash
 
-# builds fine on OSX 10.8.5 / clang 5.0.0
-
 # if you'd like to build a conda package from a local directory
 # then comment out the "source" section in meta.yaml
 # and replace $LOCAL_SRC_DIR to your pythonocc-core directory
 #export LOCAL_SRC_DIR=/path/to/pythonocc-core/
 #cp -r $LOCAL_SRC_DIR .
 
+if [ `uname` == Darwin ]; then
+    PY_LIB="libpython${PY_VER}.dylib"
+else
+    if [ "$PY3K" == "1" ]; then
+        PY_LIB="libpython${PY_VER}m.so"
+    else 
+        PY_LIB="libpython${PY_VER}.so"
+    fi
+fi
+
 echo "conda build directory is:" `pwd`
 export PYTHONOCC_VERSION=`python -c "import OCC;print OCC.VERSION"`
 echo "building pythonocc-core version:" $PYTHONOCC_VERSION
 
-export MACOSX_DEPLOYMENT_TARGET=10.6
-export DYLD_LIBRARY_PATH="$PREFIX/lib:$DYLD_LIBRARY_PATH"
-export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
 
 backup_prefix=$PREFIX
 
-ncpus=1
-if test -x /usr/bin/getconf; then
-    ncpus=$(/usr/bin/getconf _NPROCESSORS_ONLN)
-fi
-
-#swig_incl_dir=`$PREFIX/bin/swig -swiglib`
-# see: https://github.com/ContinuumIO/anaconda-issues/issues/164
-# setting the $SWIG_LIB variable as a temporary bypass
-export SWIG_LIB=$PREFIX/share/swig/2.0.10
-echo "swig <<<"$SWIG_LIB">>>"
-
 echo "Timestamp" && date
 cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DCMAKE_OSX_DEPLOYMENT_TARGET=10.8 \
-      -DOCE_INCLUDE_PATH=$PREFIX/include/oce \
-      -DPYTHON_LIBRARY=$PREFIX/lib/libpython2.7.dylib \
-      -DSWIG_EXECUTABLE=$PREFIX/bin/swig \
-      -DSWIG_DIR=$SWIG_LIB \
-      -DOCE_LIB_PATH=$PREFIX/lib\
-      -DpythonOCC_INSTALL_DIRECTORY=$PREFIX/lib/python2.7/site-packages/OCC \
-      -DpythonOCC_WRAP_DATAEXCHANGE=ON \
-      -DpythonOCC_WRAP_MODEL=ON \
-      -DpythonOCC_WRAP_VISU=ON \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DOCE_DIR=$PREFIX/lib \
+      -DPYTHON_EXECUTABLE:FILEPATH=$PYTHON \
+      -DPYTHON_INCLUDE_DIR:PATH=$PREFIX/include/python$PY_VER \
+      -DPYTHON_LIBRARY:FILEPATH=$PREFIX/lib/${PY_LIB} \
+      -DPYTHONOCC_INSTALL_DIRECTORY=$SP_DIR/OCC \
+      -DPYTHONOCC_WRAP_DATAEXCHANGE=ON \
+      -DPYTHONOCC_WRAP_OCAF=ON \
+      -DPYTHONOCC_WRAP_VISU=ON \
       $SRC_DIR
 
 echo ""
 echo "Timestamp" && date
 echo "Starting build with -j$ncpus ..."
-make -j$ncpus
+make -j $CPU_COUNT
 make install
+
+# copy the swig interface files. There are software projects
+# that might require these files to build own modules on top
+# of pythonocc-core
+mkdir -p $PREFIX/src
+mkdir -p $PREFIX/src/pythonocc-core
+cp -r src $PREFIX/src/pythonocc-core
+
 echo "Done building and installing pythonocc-core" && date

--- a/conda-pkg/pythonocc-core/fix_graphicshr_location.patch
+++ b/conda-pkg/pythonocc-core/fix_graphicshr_location.patch
@@ -1,0 +1,15 @@
+# Fixes the changed path of TKOpenGL.dll
+
+diff --git src/addons/Display/OCCViewer.py src/addons/Display/OCCViewer.py
+index 7dd04d5..f460da4 100644
+--- src/addons/Display/OCCViewer.py
++++ src/addons/Display/OCCViewer.py
+@@ -58,7 +58,7 @@ if sys.platform == "win32":  # all of this is win specific
+     # if the CSF_GraphicShr variable is not set
+     # it should point to the TKOpenGl.dll library that is shipped with pythonocc binary
+     if not "CSF_GraphicShr" in os.environ:
+-        os.environ["CSF_GraphicShr"] = os.path.join(os.path.dirname(OCC.Aspect.__file__), "TKOpenGl.dll")
++        os.environ["CSF_GraphicShr"] = os.path.join(sys.prefix, "Library", "bin", "TKOpenGl.dll")
+ 
+ 
+ def color(r, g, b):

--- a/conda-pkg/pythonocc-core/meta.yaml
+++ b/conda-pkg/pythonocc-core/meta.yaml
@@ -1,39 +1,38 @@
 package:
   name: pythonocc-core
-  version: 0.16.0
+  version: 0.16.3dev
 
 source:
-    git_url: https://github.com/tpaviot/pythonocc-core.git
-    git_tag: 0.16.0
+    git_url: https://github.com/tpaviot/pythonocc-core.git             [unix]
+    git_tag: master # only master contains important fixes             [unix]
+    fn: pythonocc-core-master.zip                                      [win]
+    url: https://github.com/tpaviot/pythonocc-core/archive/master.zip  [win]
+    patches:
+      - fix_graphicshr_location.patch
 
 build:
-  number: 0
+  number: 1
   binary_relocation: true
 
 requirements:
   build:
+    - ninja             [win]
+    - patch             [win]
     - cmake
     - python
-    - opencascade_community_edition
-    - swig 2.0.10
+    - opencascade_community_edition ==0.16.1
+    - swig
+    - gcc               [linux]
 
   run:
     - python
-    - opencascade_community_edition
+    - opencascade_community_edition ==0.16.1
 
-#test:
-#  commands:
-#    # You can put test commands to be run here.  Use this to test that the
-#    # entry points work.
-#    - nosetests test/run_tests.py
-#
-#
-#  # You can also put a file called run_test.py in the recipe that will be run
-#  # at test time.
-#
-#  requires:
-#    # Put any additional test requirements here.  For example
-#    - nose
+test:
+  imports:
+    - OCC
+    - OCC.BRepPrimAPI
+
 
 about:
   home: https://github.com/tpaviot/pythonocc-core


### PR DESCRIPTION
I added support for all platforms (win, linux, mac). The changes were minor and similar to the changes in PR #9.

In addition, I installed all swig interface files (*.i) to $PREFIX/src/pythonocc-core. These might be required for 3rdparty modules that build on top of pythonocc-core (e.g. [tigl](https://github.com/DLR-SC/tigl) does so).
