### PR TITLE
Removed system libraries from OCE exports file on linux

### DIFF
--- a/conda-pkg/OCE/OCE-016/build.sh
+++ b/conda-pkg/OCE/OCE-016/build.sh
@@ -43,6 +43,10 @@ echo "Starting build with -j $CPU_COUNT ..."
 make -j $CPU_COUNT | grep Built
 make install
 
+if [ `uname` != Darwin ]; then
+    python $RECIPE_DIR/remove-system-libs.py $PREFIX/lib/OCE-libraries-release.cmake
+fi
+
 # Run OCE tests
 # <<< FAILS FOR THE MOMENT >>>
 

--- a/conda-pkg/OCE/OCE-016/meta.yaml
+++ b/conda-pkg/OCE/OCE-016/meta.yaml
@@ -15,7 +15,7 @@ source:
     - retina.patch       [osx]
 
 build:
-   number: 3
+   number: 4
    binary_relocation: true # (defaults to true)
    features:
     - vc9                [win and py27]

--- a/conda-pkg/OCE/OCE-016/remove-system-libs.py
+++ b/conda-pkg/OCE/OCE-016/remove-system-libs.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# @author: Martin Siggel <martin.siggel@dlr.de>
+#
+# This script fixes the cmake exports file by
+# removing explicit linking to system libraries
+
+import sys, re
+
+def remove_absolute_paths(line):
+    """
+    Removes libraries from the line that are found under /usr
+    """
+    return re.sub('/usr/[-_a-zA-Z0-9/]+.so[;]?', '', line)
+
+def fix_paths(filename):
+    with open(filename) as f:
+        lines = f.readlines()
+
+        # just select lines containing string IMPORTED_LINK_INTERFACE_LIBRARIES
+        for i, line in enumerate(lines):
+            if "IMPORTED_LINK_INTERFACE_LIBRARIES" in line:
+                lines[i] = remove_absolute_paths(line)
+        
+    fout = open(filename,'w')
+    fout.write("".join(lines))
+    fout.close()
+
+if __name__ == "__main__":
+    assert(len(sys.argv) == 2)
+
+    filename = sys.argv[1]
+    fix_paths(filename)
+
+


### PR DESCRIPTION
This is necessary to provide a relocatable package. Linux distributions install system libraries into different locations. Hard coded paths are therefore problematic. As the OCE libs are linked dynamically, there is no need to relink the system libs.

Fixes issue #21
